### PR TITLE
Handle large jobs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,8 +97,15 @@ JackdClient.prototype.connect = async function() {
 
   this.pending = []
 
+  let dataBuffer = ''
+
   socket.on('data', async response => {
-    const chunks = response.split('\r\n')
+    if (!response.endsWith('\r\n')) {
+      dataBuffer += response
+      return
+    }
+    const chunks = (dataBuffer + response).split('\r\n')
+    dataBuffer = ''
 
     while (chunks.length) {
       const chunk = chunks.shift()

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -52,7 +52,7 @@ describe('jackd', function() {
       await this.client.delete(id)
     })
 
-    it.only('can insert jobs with priority', async function() {
+    it('can insert jobs with priority', async function() {
       const id = await this.client.put({ foo: 'bar' }, { priority: 12342342 })
       expect(id).to.be.ok
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -132,6 +132,18 @@ describe('jackd', function() {
       await this.client.delete(id1)
       await this.client.delete(id2)
     })
+
+    it('can receive huge jobs', async function() {
+      // job larger than a socket data frame
+      const hugeText = new Array(100000).join('a');
+      const id = await this.client.put(hugeText)
+      const job = await this.client.reserve()
+
+      expect(job.id).to.equal(id)
+      expect(job.payload).to.equal(hugeText)
+
+      await this.client.delete(id)
+    })
   })
 
   describe('multi-part commands', function() {


### PR DESCRIPTION
When a job is bigger than the streaming data event from the socket, the jackd library starts to do unexpected things like 1) passing empty payloads, 2) resolving `reserve()` to a function instead of an object.

Now, the data event will get stored in memory until it reaches the end of the beanstalk command or response (`\r\n`).
