### PR TITLE
Fixed reserveWithTimeout & made connect options optional

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,7 +7,7 @@ export = JackdClient
 declare class JackdClient {
   constructor()
 
-  connect(options: JackdClient.ConnectOptions): Promise<JackdClient>
+  connect(options?: JackdClient.ConnectOptions): Promise<JackdClient>
   disconnect(): Promise<void>
 
   put(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,6 +15,7 @@ declare class JackdClient {
     options?: JackdClient.PutOptions
   ): Promise<void>
   reserve(): Promise<JackdClient.Job>
+  reserveWithTimeout(timeoutSeconds: number): Promise<JackdClient.Job>
   delete(jobId: string): Promise<void>
   release(jobId: string, options?: JackdClient.ReleaseOptions): Promise<void>
   bury(jobId: string): Promise<void>

--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,7 @@ JackdClient.prototype.reserve = createCommandHandler(
 JackdClient.prototype.reserveWithTimeout = createCommandHandler(
   seconds => `reserve-with-timeout ${seconds}\r\n`,
   reserveResponseHandler,
-  true
+  false
 )
 
 function reserveResponseHandler(response) {

--- a/src/index.js
+++ b/src/index.js
@@ -117,10 +117,15 @@ JackdClient.prototype.connect = async function() {
         break
       }
 
-      const { handler, multipart } = this.pending[0] || {}
+      const { command, handler, multipart } = this.pending[0] || {};
+
+      const isReserveWithTimeout = command.indexOf("reserve-with-timeout") !== -1;
 
       if (handler && containsCommand && multipart && !pendingCommandResult) {
         pendingCommandResult = head
+        if (head === TIMED_OUT && isReserveWithTimeout) {
+          await handler(head);
+        }
       } else if (
         handler &&
         containsCommand &&
@@ -239,7 +244,7 @@ JackdClient.prototype.reserve = createCommandHandler(
 JackdClient.prototype.reserveWithTimeout = createCommandHandler(
   seconds => `reserve-with-timeout ${seconds}\r\n`,
   reserveResponseHandler,
-  false
+  true
 )
 
 function reserveResponseHandler(response) {

--- a/src/index.js
+++ b/src/index.js
@@ -118,13 +118,23 @@ JackdClient.prototype.connect = async function() {
       }
 
       const { command, handler, multipart } = this.pending[0] || {};
-
-      const isReserveWithTimeout = command.indexOf("reserve-with-timeout") !== -1;
+      
+      // indexOf !== 0
+      const reserveWithTimeoutCmd = "reserve-with-timeout";
+      let k = 0;
+      let isReserveWithTimeout = true;
+      while(k < reserveWithTimeoutCmd.length && isReserveWithTimeout) {
+        if (command[k] !== reserveWithTimeoutCmd[k]) {
+          isReserveWithTimeout = false;
+        }
+        k++;
+      }
 
       if (handler && containsCommand && multipart && !pendingCommandResult) {
-        pendingCommandResult = head
         if (head === TIMED_OUT && isReserveWithTimeout) {
           await handler(head);
+        } else {
+          pendingCommandResult = head
         }
       } else if (
         handler &&


### PR DESCRIPTION
According the README connect options are optional:
```ts
await beanstalkd.connect() // Connects to localhost:11300
await beanstalkd.connect({ host, port })
```

The current typescript definitions require the connect options:
![alt text](https://i.imgur.com/FTIHJEll.png "Typescript example")

This pull request makes the connect options optional.